### PR TITLE
feat: implement Express + WebSocket server (issue #7)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.49",
+        "@types/supertest": "^6.0.3",
         "express": "^5.2.1",
         "highlight.js": "^11.11.1",
         "nats": "^2.29.3",
@@ -18,6 +19,7 @@
         "react-markdown": "^10.1.0",
         "rehype-highlight": "^7.0.2",
         "remark-gfm": "^4.0.1",
+        "supertest": "^7.2.2",
         "ws": "^8.19.0"
       },
       "devDependencies": {
@@ -1608,6 +1610,27 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@paralleldrive/cuid2": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.3.1.tgz",
+      "integrity": "sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "^1.1.5"
+      }
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-rc.3",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.3.tgz",
@@ -2139,6 +2162,12 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/cookiejar": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@types/cookiejar/-/cookiejar-2.1.5.tgz",
+      "integrity": "sha512-he+DHOWReW0nghN24E1WUqM0efK4kI9oTqDm6XmK8ZPe2djZ90BSNdGnIyCLzCPw7/pogPlGbzI2wHGGmi4O/Q==",
+      "license": "MIT"
+    },
     "node_modules/@types/debug": {
       "version": "4.1.12",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
@@ -2227,6 +2256,12 @@
         "@types/unist": "*"
       }
     },
+    "node_modules/@types/methods": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@types/methods/-/methods-1.1.4.tgz",
+      "integrity": "sha512-ymXWVrDiCxTBE3+RIrrP533E70eA+9qu7zdWoHuOmGujkYtzf4HQF96b8nwHLqhuf4ykX61IGRIB38CC6/sImQ==",
+      "license": "MIT"
+    },
     "node_modules/@types/ms": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
@@ -2237,7 +2272,6 @@
       "version": "24.10.13",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.13.tgz",
       "integrity": "sha512-oH72nZRfDv9lADUBSo104Aq7gPHpQZc4BTx38r9xf9pg5LfP6EzSyH2n7qFmmxRQXh7YlUXODcYsg6PuTDSxGg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.16.0"
@@ -2295,6 +2329,28 @@
       "dependencies": {
         "@types/http-errors": "*",
         "@types/node": "*"
+      }
+    },
+    "node_modules/@types/superagent": {
+      "version": "8.1.9",
+      "resolved": "https://registry.npmjs.org/@types/superagent/-/superagent-8.1.9.tgz",
+      "integrity": "sha512-pTVjI73witn+9ILmoJdajHGW2jkSaOzhiFYF1Rd3EQ94kymLqB9PjD9ISg7WaALC7+dCHT0FGe9T2LktLq/3GQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/cookiejar": "^2.1.5",
+        "@types/methods": "^1.1.4",
+        "@types/node": "*",
+        "form-data": "^4.0.0"
+      }
+    },
+    "node_modules/@types/supertest": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@types/supertest/-/supertest-6.0.3.tgz",
+      "integrity": "sha512-8WzXq62EXFhJ7QsH3Ocb/iKQ/Ty9ZVWnVzoTKc9tyyFRRF3a74Tk2+TLFgaFFw364Ere+npzHKEJ6ga2LzIL7w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/methods": "^1.1.4",
+        "@types/superagent": "^8.1.0"
       }
     },
     "node_modules/@types/unist": {
@@ -2879,6 +2935,12 @@
         "dequal": "^2.0.3"
       }
     },
+    "node_modules/asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
+      "license": "MIT"
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -2906,6 +2968,12 @@
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
       "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "license": "MIT"
     },
     "node_modules/bail": {
@@ -3220,6 +3288,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/comma-separated-tokens": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
@@ -3228,6 +3308,15 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/component-emitter": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
+      "integrity": "sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/concat-map": {
@@ -3324,6 +3413,12 @@
       "engines": {
         "node": ">=6.6.0"
       }
+    },
+    "node_modules/cookiejar": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
+      "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
+      "license": "MIT"
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -3667,6 +3762,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -3696,6 +3800,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/dezalgo": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
+      "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
+      "license": "ISC",
+      "dependencies": {
+        "asap": "^2.0.0",
+        "wrappy": "1"
       }
     },
     "node_modules/dom-accessibility-api": {
@@ -3794,6 +3908,21 @@
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -4179,6 +4308,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+      "license": "MIT"
+    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -4307,6 +4442,60 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/formidable": {
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-3.5.4.tgz",
+      "integrity": "sha512-YikH+7CUTOtP44ZTnUhR7Ic2UASBPOqmaRkRKxRbywPTe5VxF7RRCck4af9wutiZ/QKM5nME9Bie2fFaPz5Gug==",
+      "license": "MIT",
+      "dependencies": {
+        "@paralleldrive/cuid2": "^2.2.2",
+        "dezalgo": "^1.0.4",
+        "once": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/tunnckoCore/commissions"
       }
     },
     "node_modules/forwarded": {
@@ -4474,6 +4663,21 @@
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
       "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
       "engines": {
         "node": ">= 0.4"
       },
@@ -5535,6 +5739,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/micromark": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
@@ -6097,6 +6310,18 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/mime": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
     },
     "node_modules/mime-db": {
       "version": "1.54.0",
@@ -7258,6 +7483,40 @@
         "inline-style-parser": "0.2.7"
       }
     },
+    "node_modules/superagent": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-10.3.0.tgz",
+      "integrity": "sha512-B+4Ik7ROgVKrQsXTV0Jwp2u+PXYLSlqtDAhYnkkD+zn3yg8s/zjA2MeGayPoY/KICrbitwneDHrjSotxKL+0XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "component-emitter": "^1.3.1",
+        "cookiejar": "^2.1.4",
+        "debug": "^4.3.7",
+        "fast-safe-stringify": "^2.1.1",
+        "form-data": "^4.0.5",
+        "formidable": "^3.5.4",
+        "methods": "^1.1.2",
+        "mime": "2.6.0",
+        "qs": "^6.14.1"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
+    "node_modules/supertest": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-7.2.2.tgz",
+      "integrity": "sha512-oK8WG9diS3DlhdUkcFn4tkNIiIbBx9lI2ClF8K+b2/m8Eyv47LSawxUzZQSNKUrVb2KsqeTDCcjAAVPYaSLVTA==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie-signature": "^1.2.2",
+        "methods": "^1.1.2",
+        "superagent": "^10.3.0"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -7538,7 +7797,6 @@
       "version": "7.16.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
       "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/unified": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.2.49",
+    "@types/supertest": "^6.0.3",
     "express": "^5.2.1",
     "highlight.js": "^11.11.1",
     "nats": "^2.29.3",
@@ -24,6 +25,7 @@
     "react-markdown": "^10.1.0",
     "rehype-highlight": "^7.0.2",
     "remark-gfm": "^4.0.1",
+    "supertest": "^7.2.2",
     "ws": "^8.19.0"
   },
   "devDependencies": {

--- a/src/server/github.ts
+++ b/src/server/github.ts
@@ -1,0 +1,70 @@
+import { execSync } from 'child_process'
+import type { IssueGraph, IssueNode } from '../client/types.ts'
+
+/**
+ * Parses "Blocked by" links from an issue body.
+ * Looks for lines like "- #N" under a "Blocked by" heading.
+ */
+function parseBlockedBy(body: string): number[] {
+  const blockedBy: number[] = []
+  const lines = body.split('\n')
+  let inBlockedBy = false
+
+  for (const line of lines) {
+    if (/blocked\s+by/i.test(line)) {
+      inBlockedBy = true
+      continue
+    }
+    if (inBlockedBy) {
+      const match = line.match(/^[-*]\s+#(\d+)/)
+      if (match) {
+        blockedBy.push(parseInt(match[1], 10))
+      } else if (line.trim() === '') {
+        continue
+      } else if (/^#/.test(line.trim()) || /^##/.test(line.trim())) {
+        break
+      }
+    }
+  }
+
+  return blockedBy
+}
+
+/**
+ * Determines the issue type from label names.
+ */
+function parseType(labels: string[]): IssueNode['type'] {
+  if (labels.includes('Feature')) return 'Feature'
+  if (labels.includes('Task')) return 'Task'
+  if (labels.includes('Bug')) return 'Bug'
+  return null
+}
+
+/**
+ * Loads the issue dependency graph for the given GitHub repository using the `gh` CLI.
+ */
+export async function loadIssueGraph(repo: string): Promise<IssueGraph> {
+  const json = execSync(
+    `gh issue list --repo ${repo} --state all --limit 100 --json number,title,state,labels,body`,
+    { encoding: 'utf8' },
+  )
+
+  const issues = JSON.parse(json) as Array<{
+    number: number
+    title: string
+    state: string
+    labels: Array<{ name: string }>
+    body: string
+  }>
+
+  const nodes: IssueNode[] = issues.map((issue) => ({
+    number: issue.number,
+    title: issue.title,
+    state: issue.state === 'OPEN' || issue.state === 'open' ? 'open' : 'closed',
+    type: parseType(issue.labels.map((l) => l.name)),
+    external: false,
+    blockedBy: parseBlockedBy(issue.body ?? ''),
+  }))
+
+  return { nodes }
+}

--- a/src/tests/server.test.ts
+++ b/src/tests/server.test.ts
@@ -1,0 +1,235 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import request from 'supertest'
+import { WebSocket } from 'ws'
+import type { AgentId, AgentEvent, PoolState, ServerMessage } from '../client/types.ts'
+
+// ---------------------------------------------------------------------------
+// Mock agentPool module
+// ---------------------------------------------------------------------------
+
+type AgentEventListener = (agentId: AgentId, event: AgentEvent) => void
+
+const mockListeners = new Set<AgentEventListener>()
+
+const mockPool: PoolState = [
+  { id: 'supervisor', role: 'supervisor', status: 'idle', sessionId: undefined },
+  { id: 'worker-0', role: 'worker', status: 'idle', sessionId: undefined },
+  { id: 'worker-1', role: 'worker', status: 'idle', sessionId: undefined },
+  { id: 'worker-2', role: 'worker', status: 'idle', sessionId: undefined },
+]
+
+const mockAgentPool = {
+  getPool: vi.fn(() => mockPool),
+  registerListener: vi.fn((cb: AgentEventListener) => {
+    mockListeners.add(cb)
+    return () => mockListeners.delete(cb)
+  }),
+  injectMessage: vi.fn(),
+  interrupt: vi.fn(),
+}
+
+vi.mock('../server/agentPool.ts', () => ({
+  createAgentPool: vi.fn(() => Promise.resolve(mockAgentPool)),
+}))
+
+// ---------------------------------------------------------------------------
+// Mock NATS module
+// ---------------------------------------------------------------------------
+
+const mockNatsClient = {
+  publish: vi.fn(),
+  subscribe: vi.fn(() => ({ unsubscribe: vi.fn() })),
+}
+
+vi.mock('../server/nats.ts', () => ({
+  getNatsConnection: vi.fn(() => Promise.resolve(mockNatsClient)),
+  TOPIC_SUPERVISOR: 'epik.supervisor',
+  TOPIC_WORKER_0: 'epik.worker.0',
+  TOPIC_WORKER_1: 'epik.worker.1',
+  TOPIC_WORKER_2: 'epik.worker.2',
+  TOPIC_LOG: 'epik.log',
+}))
+
+// ---------------------------------------------------------------------------
+// Mock github module
+// ---------------------------------------------------------------------------
+
+vi.mock('../server/github.ts', () => ({
+  loadIssueGraph: vi.fn(() =>
+    Promise.resolve({
+      nodes: [
+        {
+          number: 1,
+          title: 'Test issue',
+          state: 'open',
+          type: 'Task',
+          external: false,
+          blockedBy: [],
+        },
+      ],
+    }),
+  ),
+}))
+
+// ---------------------------------------------------------------------------
+// Test setup
+// ---------------------------------------------------------------------------
+
+let serverModule: typeof import('../server/index.ts')
+
+beforeEach(async () => {
+  vi.resetModules()
+  mockListeners.clear()
+  mockAgentPool.getPool.mockReturnValue(mockPool)
+  serverModule = await import('../server/index.ts')
+})
+
+afterEach(() => {
+  serverModule.server.close()
+})
+
+// ---------------------------------------------------------------------------
+// REST endpoint tests
+// ---------------------------------------------------------------------------
+
+describe('GET /api/pool', () => {
+  it('returns 200 with pool state JSON', async () => {
+    const res = await request(serverModule.app).get('/api/pool')
+    expect(res.status).toBe(200)
+    expect(res.body).toEqual(mockPool)
+  })
+})
+
+describe('GET /api/issues', () => {
+  it('returns 400 when repo param is missing', async () => {
+    const res = await request(serverModule.app).get('/api/issues')
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 200 with IssueGraph JSON when repo is provided', async () => {
+    const res = await request(serverModule.app).get('/api/issues?repo=owner/repo')
+    expect(res.status).toBe(200)
+    expect(res.body).toMatchObject({ nodes: expect.any(Array) })
+  })
+})
+
+describe('POST /api/start', () => {
+  it('returns 200 and publishes to supervisor NATS topic', async () => {
+    const res = await request(serverModule.app).post('/api/start').send({})
+    expect(res.status).toBe(200)
+    expect(mockNatsClient.publish).toHaveBeenCalledWith('epik.supervisor', expect.any(String))
+  })
+})
+
+describe('POST /api/message', () => {
+  it('returns 400 when agentId or text is missing', async () => {
+    const res = await request(serverModule.app).post('/api/message').send({ agentId: 'supervisor' })
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 200 and calls injectMessage on the pool', async () => {
+    const res = await request(serverModule.app)
+      .post('/api/message')
+      .send({ agentId: 'supervisor', text: 'hello' })
+    expect(res.status).toBe(200)
+    expect(mockAgentPool.injectMessage).toHaveBeenCalledWith('supervisor', 'hello')
+  })
+})
+
+describe('POST /api/interrupt', () => {
+  it('returns 400 when agentId is missing', async () => {
+    const res = await request(serverModule.app).post('/api/interrupt').send({})
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 200 and calls interrupt on the pool', async () => {
+    const res = await request(serverModule.app).post('/api/interrupt').send({ agentId: 'worker-0' })
+    expect(res.status).toBe(200)
+    expect(mockAgentPool.interrupt).toHaveBeenCalledWith('worker-0')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// WebSocket tests
+// ---------------------------------------------------------------------------
+
+describe('WebSocket /ws', () => {
+  it('sends pool_state on connect', async () => {
+    await new Promise<void>((resolve, reject) => {
+      // Start server listening on a random port for the WS test
+      serverModule.server.listen(0, () => {
+        const addr = serverModule.server.address() as { port: number }
+        const ws = new WebSocket(`ws://localhost:${addr.port}/ws`)
+
+        ws.on('message', (data) => {
+          const msg: ServerMessage = JSON.parse(data.toString())
+          if (msg.type === 'pool_state') {
+            expect(msg.pool).toEqual(mockPool)
+            ws.close()
+            resolve()
+          }
+        })
+
+        ws.on('error', reject)
+      })
+    })
+  })
+
+  it('broadcasts agent_event to connected clients', async () => {
+    await new Promise<void>((resolve, reject) => {
+      serverModule.server.listen(0, () => {
+        const addr = serverModule.server.address() as { port: number }
+        const ws = new WebSocket(`ws://localhost:${addr.port}/ws`)
+
+        const received: ServerMessage[] = []
+
+        ws.on('message', (data) => {
+          const msg: ServerMessage = JSON.parse(data.toString())
+          received.push(msg)
+
+          // After receiving pool_state, trigger an agent event
+          if (msg.type === 'pool_state') {
+            // Broadcast an event via all registered listeners
+            for (const cb of mockListeners) {
+              cb('supervisor', { kind: 'text_delta', text: 'hello' })
+            }
+          }
+
+          if (msg.type === 'agent_event') {
+            expect(msg.agentId).toBe('supervisor')
+            expect(msg.event).toEqual({ kind: 'text_delta', text: 'hello' })
+            ws.close()
+            resolve()
+          }
+        })
+
+        ws.on('error', reject)
+      })
+    })
+  })
+
+  it('cleans up listener when client disconnects', async () => {
+    const initialListenerCount = mockListeners.size
+
+    await new Promise<void>((resolve, reject) => {
+      serverModule.server.listen(0, () => {
+        const addr = serverModule.server.address() as { port: number }
+        const ws = new WebSocket(`ws://localhost:${addr.port}/ws`)
+
+        ws.on('message', () => {
+          // After first message, close the connection
+          ws.close()
+        })
+
+        ws.on('close', async () => {
+          // Give a tick for cleanup
+          await new Promise((r) => setTimeout(r, 20))
+          expect(mockListeners.size).toBe(initialListenerCount)
+          resolve()
+        })
+
+        ws.on('error', reject)
+      })
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- Implements the full Express HTTP + WebSocket server (`src/server/index.ts`) bridging the browser and the agent pool
- Adds `src/server/github.ts` with `loadIssueGraph()` to fetch issue graphs from GitHub via `gh` CLI
- Adds `supertest` dependency for HTTP endpoint testing

## REST endpoints

| Method | Path | Description |
|--------|------|-------------|
| GET | `/api/issues?repo=owner/repo` | Returns `IssueGraph` JSON; 400 if `repo` param missing |
| GET | `/api/pool` | Returns `PoolState` JSON |
| POST | `/api/start` | Publishes `start` to `epik.supervisor` NATS topic |
| POST | `/api/message` | Calls `pool.injectMessage(agentId, text)`; 400 if fields missing |
| POST | `/api/interrupt` | Calls `pool.interrupt(agentId)`; 400 if `agentId` missing |

## WebSocket `/ws`

- Sends `{ type: 'pool_state', pool }` immediately on connect
- Streams all `AgentEvent`s as `{ type: 'agent_event', agentId, event }` via registered pool listener
- Unregisters listener cleanly on disconnect

## Technical decisions

- `createAgentPool()` is called once at module load and shared across all request handlers via a `Promise` singleton — avoids re-initialising the pool on each request
- `loadIssueGraph()` shells out to `gh issue list` (matching the pattern in `runner.ts`) and parses "Blocked by" sections from issue bodies
- WebSocket listener lifecycle is tied to the individual WebSocket connection (registered on connect, deregistered on close)

## Test plan

- [x] HTTP endpoint tests with `supertest` (correct status codes, JSON shapes, mock validation)
- [x] WebSocket test: pool_state received on connect
- [x] WebSocket test: agent_event broadcast to connected client
- [x] WebSocket test: listener cleanup on disconnect
- [x] All 83 tests passing, lint clean, Prettier clean

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)