### PR TITLE
feat: add GitHub issue graph loader (src/server/github.ts)

### DIFF
--- a/src/server/github.ts
+++ b/src/server/github.ts
@@ -1,28 +1,76 @@
-import { execSync } from 'child_process'
+import { execFile } from 'child_process'
 import type { IssueGraph, IssueNode } from '../client/types.ts'
 
-/**
- * Parses "Blocked by" links from an issue body.
- * Looks for lines like "- #N" under a "Blocked by" heading.
- */
-function parseBlockedBy(body: string): number[] {
-  const blockedBy: number[] = []
-  const lines = body.split('\n')
-  let inBlockedBy = false
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
 
-  for (const line of lines) {
-    if (/blocked\s+by/i.test(line)) {
-      inBlockedBy = true
+/** CI check rollup state as reported by gh. */
+export type ChecksState = 'success' | 'failure' | 'pending'
+
+/** Result of inspecting a PR associated with a GitHub issue. */
+export interface PRStatus {
+  /** PR number on GitHub. */
+  prNumber: number
+  /** Aggregated CI check state. */
+  checksState: ChecksState
+  /** Whether the PR branch can be cleanly merged. */
+  mergeable: boolean
+}
+
+// ---------------------------------------------------------------------------
+// Internal types
+// ---------------------------------------------------------------------------
+
+/** Raw GitHub issue shape returned by `gh api /repos/.../issues`. */
+interface RawIssue {
+  number: number
+  title: string
+  state: string
+  labels: Array<{ name: string }>
+  body: string | null
+}
+
+/** Raw PR shape returned by `gh api /repos/.../pulls`. */
+interface RawPR {
+  number: number
+  body: string | null
+  mergeable: 'MERGEABLE' | 'CONFLICTING' | 'UNKNOWN' | null
+  statusCheckRollup: { state: string } | null
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+const TYPE_LABELS = new Set(['Feature', 'Task', 'Bug'])
+
+/**
+ * Parse the "## Blocked by" section from an issue body.
+ *
+ * Recognises lines of the form `- #N` within the section that follows
+ * a `## Blocked by` heading. Stops at the next `##` heading.
+ */
+function parseBlockedBy(body: string | null): number[] {
+  if (!body) return []
+
+  const blockedBy: number[] = []
+  let inSection = false
+
+  for (const line of body.split('\n')) {
+    const trimmed = line.trim()
+
+    if (/^##\s+blocked\s+by/i.test(trimmed)) {
+      inSection = true
       continue
     }
-    if (inBlockedBy) {
-      const match = line.match(/^[-*]\s+#(\d+)/)
+
+    if (inSection) {
+      if (/^##/.test(trimmed)) break // next heading — stop
+
+      const match = trimmed.match(/^-\s+#(\d+)/)
       if (match) {
         blockedBy.push(parseInt(match[1], 10))
-      } else if (line.trim() === '') {
-        continue
-      } else if (/^#/.test(line.trim()) || /^##/.test(line.trim())) {
-        break
       }
     }
   }
@@ -31,40 +79,134 @@ function parseBlockedBy(body: string): number[] {
 }
 
 /**
- * Determines the issue type from label names.
+ * Extract the recognised type label from a list of labels, or null.
  */
-function parseType(labels: string[]): IssueNode['type'] {
-  if (labels.includes('Feature')) return 'Feature'
-  if (labels.includes('Task')) return 'Task'
-  if (labels.includes('Bug')) return 'Bug'
+function parseType(labels: Array<{ name: string }>): IssueNode['type'] {
+  for (const label of labels) {
+    if (TYPE_LABELS.has(label.name)) {
+      return label.name as IssueNode['type']
+    }
+  }
   return null
 }
 
 /**
- * Loads the issue dependency graph for the given GitHub repository using the `gh` CLI.
+ * Promisified wrapper around execFile for the `gh` CLI.
+ *
+ * Exported so tests can spy on it or inject a replacement via the `exec`
+ * parameter of the public API functions.
  */
-export async function loadIssueGraph(repo: string): Promise<IssueGraph> {
-  const json = execSync(
-    `gh issue list --repo ${repo} --state all --limit 100 --json number,title,state,labels,body`,
-    { encoding: 'utf8' },
-  )
+export function runGhCommand(args: string[]): Promise<string> {
+  return new Promise((resolve, reject) => {
+    execFile('gh', args, { maxBuffer: 10 * 1024 * 1024 }, (err, stdout) => {
+      if (err) {
+        reject(err)
+      } else {
+        resolve(stdout)
+      }
+    })
+  })
+}
 
-  const issues = JSON.parse(json) as Array<{
-    number: number
-    title: string
-    state: string
-    labels: Array<{ name: string }>
-    body: string
-  }>
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Load the issue dependency graph for a GitHub repository.
+ *
+ * Calls `gh api /repos/{owner}/{repo}/issues?state=open&per_page=100` and
+ * parses each issue body for "## Blocked by" sections to build the graph.
+ *
+ * @param owner - GitHub organisation or user name.
+ * @param repo  - Repository name.
+ * @param exec  - Optional override for the gh runner (used in tests).
+ * @returns     The resolved issue dependency graph.
+ */
+export async function loadIssueGraph(
+  owner: string,
+  repo: string,
+  exec: (args: string[]) => Promise<string> = runGhCommand,
+): Promise<IssueGraph> {
+  const raw = await exec([
+    'api',
+    `/repos/${owner}/${repo}/issues`,
+    '--method',
+    'GET',
+    '-f',
+    'state=open',
+    '-f',
+    'per_page=100',
+  ])
+
+  const issues: RawIssue[] = JSON.parse(raw)
 
   const nodes: IssueNode[] = issues.map((issue) => ({
     number: issue.number,
     title: issue.title,
-    state: issue.state === 'OPEN' || issue.state === 'open' ? 'open' : 'closed',
-    type: parseType(issue.labels.map((l) => l.name)),
+    state: issue.state as 'open' | 'closed',
+    type: parseType(issue.labels),
     external: false,
-    blockedBy: parseBlockedBy(issue.body ?? ''),
+    blockedBy: parseBlockedBy(issue.body),
   }))
 
   return { nodes }
+}
+
+/**
+ * Find the PR associated with a GitHub issue and return its CI status.
+ *
+ * Uses `gh api /repos/{owner}/{repo}/pulls` to list open PRs and matches
+ * by issue number referenced in the PR body.
+ *
+ * Returns `null` if no open PR is found for the given issue.
+ *
+ * @param owner       - GitHub organisation or user name.
+ * @param repo        - Repository name.
+ * @param issueNumber - The issue number to look up.
+ * @param exec        - Optional override for the gh runner (used in tests).
+ */
+export async function getPRStatus(
+  owner: string,
+  repo: string,
+  issueNumber: number,
+  exec: (args: string[]) => Promise<string> = runGhCommand,
+): Promise<PRStatus | null> {
+  const raw = await exec([
+    'api',
+    `/repos/${owner}/${repo}/pulls`,
+    '--method',
+    'GET',
+    '-f',
+    'state=open',
+    '-f',
+    'per_page=100',
+  ])
+
+  const prs: RawPR[] = JSON.parse(raw)
+
+  const issueRef = new RegExp(
+    `(closes|fixes|resolves|close|fix|resolve)\\s+#${issueNumber}\\b`,
+    'i',
+  )
+
+  const pr = prs.find((p) => p.body && issueRef.test(p.body))
+
+  if (!pr) return null
+
+  let checksState: ChecksState
+  const rollupState = pr.statusCheckRollup?.state?.toUpperCase()
+  if (rollupState === 'SUCCESS') {
+    checksState = 'success'
+  } else if (rollupState === 'FAILURE' || rollupState === 'ERROR') {
+    checksState = 'failure'
+  } else {
+    checksState = 'pending'
+  }
+
+  return {
+    prNumber: pr.number,
+    checksState,
+    mergeable: pr.mergeable === 'MERGEABLE',
+  }
 }

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -28,8 +28,13 @@ app.get('/api/issues', async (req, res) => {
     res.status(400).json({ error: 'Missing required query parameter: repo' })
     return
   }
+  const [owner, repoName] = repo.split('/')
+  if (!owner || !repoName) {
+    res.status(400).json({ error: 'repo must be in owner/repo format' })
+    return
+  }
   try {
-    const graph = await loadIssueGraph(repo)
+    const graph = await loadIssueGraph(owner, repoName)
     res.json(graph)
   } catch (err) {
     res.status(500).json({ error: String(err) })

--- a/src/tests/github.test.ts
+++ b/src/tests/github.test.ts
@@ -1,0 +1,224 @@
+import { describe, it, expect, vi } from 'vitest'
+import { loadIssueGraph, getPRStatus } from '../server/github.ts'
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+/** Minimal gh api /repos/.../issues response shape */
+const ISSUE_FIXTURE = [
+  {
+    number: 1,
+    title: 'Root feature',
+    state: 'open',
+    labels: [{ name: 'Feature' }],
+    body: '## Overview\n\nA root feature with no dependencies.',
+  },
+  {
+    number: 2,
+    title: 'Blocked task',
+    state: 'open',
+    labels: [{ name: 'Task' }],
+    body: '## Overview\n\nA task.\n\n## Blocked by\n\n- #1\n',
+  },
+  {
+    number: 3,
+    title: 'Multi-blocked task',
+    state: 'open',
+    labels: [{ name: 'Bug' }],
+    body: '## Blocked by\n\n- #1\n- #2\n',
+  },
+  {
+    number: 4,
+    title: 'No type label',
+    state: 'open',
+    labels: [],
+    body: null,
+  },
+  {
+    number: 5,
+    title: 'Unlabelled with body',
+    state: 'open',
+    labels: [{ name: 'enhancement' }],
+    body: 'Some description with no blocked-by section.',
+  },
+]
+
+/** PR list fixture for getPRStatus */
+const PR_FIXTURE_OPEN = [
+  {
+    number: 101,
+    title: 'Fix issue 2',
+    state: 'open',
+    headRefName: 'feature/blocked-task-2',
+    body: 'Closes #2',
+    mergeable: 'MERGEABLE',
+    statusCheckRollup: { state: 'SUCCESS' },
+  },
+]
+
+const PR_FIXTURE_FAILING = [
+  {
+    number: 102,
+    title: 'Fix issue 3',
+    state: 'open',
+    headRefName: 'feature/multi-blocked-3',
+    body: 'Closes #3',
+    mergeable: 'CONFLICTING',
+    statusCheckRollup: { state: 'FAILURE' },
+  },
+]
+
+const PR_FIXTURE_PENDING = [
+  {
+    number: 103,
+    title: 'Fix issue 1',
+    state: 'open',
+    headRefName: 'feature/root-feature-1',
+    body: 'Closes #1',
+    mergeable: 'MERGEABLE',
+    statusCheckRollup: null,
+  },
+]
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Build a mock exec function that resolves with the serialised fixture. */
+function makeExec(fixture: object[]): (args: string[]) => Promise<string> {
+  return vi.fn().mockResolvedValue(JSON.stringify(fixture))
+}
+
+/** Build a mock exec function that rejects with the given error. */
+function makeExecError(err: Error): (args: string[]) => Promise<string> {
+  return vi.fn().mockRejectedValue(err)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('github', () => {
+  // -------------------------------------------------------------------------
+  // loadIssueGraph
+  // -------------------------------------------------------------------------
+
+  describe('loadIssueGraph', () => {
+    it('returns an IssueGraph with nodes for each open issue', async () => {
+      const graph = await loadIssueGraph('owner', 'repo', makeExec(ISSUE_FIXTURE))
+      expect(graph.nodes).toHaveLength(ISSUE_FIXTURE.length)
+    })
+
+    it('sets the correct issue number and title on each node', async () => {
+      const graph = await loadIssueGraph('owner', 'repo', makeExec(ISSUE_FIXTURE))
+      const node1 = graph.nodes.find((n) => n.number === 1)
+      expect(node1?.title).toBe('Root feature')
+      expect(node1?.state).toBe('open')
+    })
+
+    it('parses a single "Blocked by" dependency', async () => {
+      const graph = await loadIssueGraph('owner', 'repo', makeExec(ISSUE_FIXTURE))
+      const node2 = graph.nodes.find((n) => n.number === 2)
+      expect(node2?.blockedBy).toEqual([1])
+    })
+
+    it('parses multiple "Blocked by" dependencies', async () => {
+      const graph = await loadIssueGraph('owner', 'repo', makeExec(ISSUE_FIXTURE))
+      const node3 = graph.nodes.find((n) => n.number === 3)
+      expect(node3?.blockedBy).toEqual([1, 2])
+    })
+
+    it('returns empty blockedBy array when no dependencies are listed', async () => {
+      const graph = await loadIssueGraph('owner', 'repo', makeExec(ISSUE_FIXTURE))
+      const node1 = graph.nodes.find((n) => n.number === 1)
+      expect(node1?.blockedBy).toEqual([])
+    })
+
+    it('returns empty blockedBy when body is null', async () => {
+      const graph = await loadIssueGraph('owner', 'repo', makeExec(ISSUE_FIXTURE))
+      const node4 = graph.nodes.find((n) => n.number === 4)
+      expect(node4?.blockedBy).toEqual([])
+    })
+
+    it('maps Feature label to type "Feature"', async () => {
+      const graph = await loadIssueGraph('owner', 'repo', makeExec(ISSUE_FIXTURE))
+      expect(graph.nodes.find((n) => n.number === 1)?.type).toBe('Feature')
+    })
+
+    it('maps Task label to type "Task"', async () => {
+      const graph = await loadIssueGraph('owner', 'repo', makeExec(ISSUE_FIXTURE))
+      expect(graph.nodes.find((n) => n.number === 2)?.type).toBe('Task')
+    })
+
+    it('maps Bug label to type "Bug"', async () => {
+      const graph = await loadIssueGraph('owner', 'repo', makeExec(ISSUE_FIXTURE))
+      expect(graph.nodes.find((n) => n.number === 3)?.type).toBe('Bug')
+    })
+
+    it('sets type to null when no recognised label is present', async () => {
+      const graph = await loadIssueGraph('owner', 'repo', makeExec(ISSUE_FIXTURE))
+      expect(graph.nodes.find((n) => n.number === 4)?.type).toBeNull()
+      expect(graph.nodes.find((n) => n.number === 5)?.type).toBeNull()
+    })
+
+    it('sets external to false for all nodes by default', async () => {
+      const graph = await loadIssueGraph('owner', 'repo', makeExec(ISSUE_FIXTURE))
+      for (const node of graph.nodes) {
+        expect(node.external).toBe(false)
+      }
+    })
+
+    it('calls gh api with the correct endpoint', async () => {
+      const exec = vi.fn<[string[]], Promise<string>>().mockResolvedValue(JSON.stringify([]))
+      await loadIssueGraph('myorg', 'myrepo', exec)
+      const [args] = exec.mock.calls[0]
+      expect(args).toContain('/repos/myorg/myrepo/issues')
+      expect(args.join(' ')).toContain('state=open')
+    })
+
+    it('handles an empty issues list', async () => {
+      const graph = await loadIssueGraph('owner', 'repo', makeExec([]))
+      expect(graph.nodes).toHaveLength(0)
+    })
+
+    it('rejects on gh cli error', async () => {
+      const exec = makeExecError(new Error('gh: not found'))
+      await expect(loadIssueGraph('owner', 'repo', exec)).rejects.toThrow('gh: not found')
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // getPRStatus
+  // -------------------------------------------------------------------------
+
+  describe('getPRStatus', () => {
+    it('returns null when no PR is associated with the issue', async () => {
+      const result = await getPRStatus('owner', 'repo', 99, makeExec([]))
+      expect(result).toBeNull()
+    })
+
+    it('returns checksState "success" when CI is green and branch is mergeable', async () => {
+      const result = await getPRStatus('owner', 'repo', 2, makeExec(PR_FIXTURE_OPEN))
+      expect(result).not.toBeNull()
+      expect(result?.checksState).toBe('success')
+      expect(result?.mergeable).toBe(true)
+    })
+
+    it('returns checksState "failure" and mergeable false when CI fails and branch conflicts', async () => {
+      const result = await getPRStatus('owner', 'repo', 3, makeExec(PR_FIXTURE_FAILING))
+      expect(result?.checksState).toBe('failure')
+      expect(result?.mergeable).toBe(false)
+    })
+
+    it('returns checksState "pending" when statusCheckRollup is null', async () => {
+      const result = await getPRStatus('owner', 'repo', 1, makeExec(PR_FIXTURE_PENDING))
+      expect(result?.checksState).toBe('pending')
+    })
+
+    it('includes prNumber in the result', async () => {
+      const result = await getPRStatus('owner', 'repo', 2, makeExec(PR_FIXTURE_OPEN))
+      expect(result?.prNumber).toBe(101)
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- Implements `loadIssueGraph(owner, repo)` which calls `gh api /repos/{owner}/{repo}/issues` and parses `## Blocked by\n- #N` sections to build `blockedBy` edges; maps `Feature`/`Task`/`Bug` labels to `IssueNode.type`
- Implements `getPRStatus(owner, repo, issueNumber)` which fetches open PRs and matches by "Closes #N" / "Fixes #N" patterns in the PR body, returning `checksState` (`success | failure | pending`) and `mergeable`
- Both functions accept an optional `exec` parameter for dependency injection (no live `gh` calls in unit tests)

## Technical decisions

- **Dependency injection over mocking**: rather than fighting vitest's jsdom environment to mock `child_process`, the `exec` parameter defaults to the real `runGhCommand` but can be replaced in tests with a `vi.fn()` returning fixture JSON. This is simpler and more explicit than module-level mocking.
- **`runGhCommand` exported**: the real execFile wrapper is a named export so callers that want the default live behaviour can also override it at a higher level if needed.
- **PR matching by body text**: uses a regex covering `closes`, `fixes`, `resolves` (and lowercase variants) to find the PR for a given issue number, consistent with GitHub's own auto-close keywords.

## Test plan

- [x] 19 unit tests with fixture JSON; no live GitHub calls
- [x] `loadIssueGraph` correctly parses `blockedBy` (single and multiple), label types, null body, and empty list
- [x] `getPRStatus` correctly maps `SUCCESS`/`FAILURE`/`null` rollup to `checksState`, `CONFLICTING` to `mergeable: false`, and returns `null` when no PR found
- [x] `npm run lint` clean
- [x] `npm run format` no changes
- [x] Full suite: 91/91 tests passing

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)