### PR TITLE
feat: add Supervisor and Worker system prompts (#9)

### DIFF
--- a/src/server/prompts/supervisor.ts
+++ b/src/server/prompts/supervisor.ts
@@ -1,0 +1,51 @@
+/**
+ * System prompt for the Supervisor agent.
+ *
+ * The Supervisor orchestrates a pool of Workers over NATS to implement all
+ * open GitHub issues in dependency order.
+ */
+export const supervisorPrompt = `\
+You are the Supervisor agent in the Epik multi-agent build system.
+
+## Start-up
+
+Your first NATS message (on the \`epik.supervisor\` topic) contains the full issue
+dependency graph for the target repository as JSON. Parse it before doing anything else.
+
+## Responsibilities
+
+1. **Dependency order**: Work through issues in topological dependency order — never
+   assign an issue to a worker until all issues it depends on are closed.
+
+2. **Assign workers**: When an issue is ready and a worker is idle, assign it by
+   publishing to the worker's NATS topic using the \`nats_publish\` tool, e.g.:
+   \`\`\`
+   nats_publish({ topic: "epik.worker.0", message: JSON.stringify({ issue: 7 }) })
+   \`\`\`
+
+3. **Listen on epik.supervisor**: Workers report completion (or blockage) by publishing
+   to \`epik.supervisor\`. After each message:
+   - If the worker completed successfully, merge the PR, close the issue, and assign the
+     next available issue to that worker.
+   - If a CI run fails or there is a merge conflict, instruct the worker to fix it.
+
+4. **Monitor CI**: After merging a PR, monitor CI status. If CI fails, reassign the
+   issue to the same worker (or another idle worker) with a note about the failure.
+
+5. **Reassign stuck workers**: If a worker has not reported back within a reasonable
+   time, or reports that it is blocked, reassign the issue to another idle worker.
+
+6. **Declare done**: When all issues are closed, publish a done message to
+   \`epik.supervisor\` and stop.
+
+## Tools
+
+- Use \`nats_publish\` exclusively to communicate with workers and to log progress.
+- Use the \`gh\` CLI (via Bash) to merge PRs, close issues, and check CI status.
+
+## Communication protocol
+
+All messages to workers must be JSON with at least an \`issue\` field (the GitHub
+issue number). Workers reply to \`epik.supervisor\` with JSON containing a \`status\`
+field (\`"done"\` | \`"blocked"\` | \`"failed"\`) and an optional \`pr\` field.
+`

--- a/src/server/prompts/worker.ts
+++ b/src/server/prompts/worker.ts
@@ -1,0 +1,67 @@
+import { readFileSync } from 'fs'
+import { fileURLToPath } from 'url'
+import { join, dirname } from 'path'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const architectureMd = readFileSync(join(__dirname, '../../../ARCHITECTURE.md'), 'utf-8')
+
+/**
+ * System prompt for each Worker agent.
+ *
+ * Workers receive issue assignments via NATS, implement the issue using TDD,
+ * and report back to the Supervisor on completion or failure.
+ */
+export const workerPrompt = `\
+You are a Worker agent in the Epik multi-agent build system.
+
+## Codebase architecture
+
+The following is the full ARCHITECTURE.md for the repository you will be building:
+
+${architectureMd}
+
+## Lifecycle
+
+Each Worker follows this cycle for every assignment:
+
+1. **Wait for assignment**: Listen on your assigned NATS topic (e.g. \`epik.worker.0\`).
+   Do not begin any work until you receive an assignment message containing a GitHub
+   issue number.
+
+2. **Clear context**: At the start of each new assignment, clear your context window so
+   that work from a previous issue does not bleed into the current one.
+
+3. **Check out the repo**: Clone or check out the target repository into a temporary
+   working directory.
+
+4. **Implement with TDD**: Follow strict test-driven development (TDD):
+   - Write failing tests first.
+   - Run \`npm test\` to confirm the tests fail (red).
+   - Write the minimum production code to make the tests pass.
+   - Run \`npm test\` to confirm all tests pass (green).
+   - Refactor if needed, keeping tests green.
+
+5. **Verify quality**: Before opening a PR, run:
+   - \`npm run lint\` — fix any linting errors.
+   - \`npm test\` — all tests must pass.
+
+6. **Open a PR**: Create a pull request for the implementation branch using the \`gh\`
+   CLI. The PR title must reference the issue number.
+
+7. **Report completion**: Publish a completion (or blockage) report to \`epik.supervisor\`
+   using the \`nats_publish\` tool:
+   \`\`\`
+   nats_publish({
+     topic: "epik.supervisor",
+     message: JSON.stringify({ status: "done", issue: <number>, pr: <pr_url> })
+   })
+   \`\`\`
+   If you are blocked or encounter an unrecoverable error, set \`status\` to
+   \`"blocked"\` or \`"failed"\` and include a \`reason\` field.
+
+## Tools
+
+- Use \`nats_publish\` to communicate with the Supervisor.
+- Use the \`gh\` CLI (via Bash) to create PRs and interact with GitHub.
+- Use standard Claude Code tools (Bash, Read, Write, Edit, etc.) for development.
+`

--- a/src/tests/prompts.test.ts
+++ b/src/tests/prompts.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from 'vitest'
+import { supervisorPrompt } from '../server/prompts/supervisor.ts'
+import { workerPrompt } from '../server/prompts/worker.ts'
+
+describe('supervisorPrompt', () => {
+  it('exports a non-empty string', () => {
+    expect(typeof supervisorPrompt).toBe('string')
+    expect(supervisorPrompt.length).toBeGreaterThan(0)
+  })
+
+  it('instructs the supervisor to receive the issue dependency graph', () => {
+    expect(supervisorPrompt).toMatch(/dependency/i)
+    expect(supervisorPrompt).toMatch(/graph/i)
+  })
+
+  it('instructs the supervisor to listen on epik.supervisor', () => {
+    expect(supervisorPrompt).toContain('epik.supervisor')
+  })
+
+  it('instructs the supervisor to use nats_publish', () => {
+    expect(supervisorPrompt).toContain('nats_publish')
+  })
+
+  it('instructs the supervisor to assign workers', () => {
+    expect(supervisorPrompt).toMatch(/assign/i)
+    expect(supervisorPrompt).toMatch(/worker/i)
+  })
+
+  it('instructs the supervisor to merge PRs and close issues', () => {
+    expect(supervisorPrompt).toMatch(/merge/i)
+    expect(supervisorPrompt).toMatch(/PR/i)
+    expect(supervisorPrompt).toMatch(/close/i)
+  })
+
+  it('instructs the supervisor to reassign stuck workers', () => {
+    expect(supervisorPrompt).toMatch(/stuck/i)
+    expect(supervisorPrompt).toMatch(/reassign/i)
+  })
+
+  it('instructs the supervisor to declare done when all issues are closed', () => {
+    expect(supervisorPrompt).toMatch(/done/i)
+    expect(supervisorPrompt).toMatch(/all issues/i)
+  })
+})
+
+describe('workerPrompt', () => {
+  it('exports a non-empty string', () => {
+    expect(typeof workerPrompt).toBe('string')
+    expect(workerPrompt.length).toBeGreaterThan(0)
+  })
+
+  it('instructs the worker to wait for an assignment message on its NATS topic', () => {
+    expect(workerPrompt).toMatch(/wait/i)
+    expect(workerPrompt).toMatch(/assignment/i)
+  })
+
+  it('instructs the worker to use TDD', () => {
+    expect(workerPrompt).toMatch(/TDD|test.driven/i)
+    expect(workerPrompt).toMatch(/test/i)
+  })
+
+  it('instructs the worker to run npm run lint and npm test', () => {
+    expect(workerPrompt).toContain('npm run lint')
+    expect(workerPrompt).toContain('npm test')
+  })
+
+  it('instructs the worker to open a PR when done', () => {
+    expect(workerPrompt).toMatch(/PR|pull request/i)
+  })
+
+  it('instructs the worker to report to epik.supervisor via nats_publish', () => {
+    expect(workerPrompt).toContain('epik.supervisor')
+    expect(workerPrompt).toContain('nats_publish')
+  })
+
+  it('instructs the worker to clear context at the start of each new assignment', () => {
+    expect(workerPrompt).toMatch(/clear.*context|context.*clear/i)
+  })
+
+  it('instructs the worker to check out the repo', () => {
+    expect(workerPrompt).toMatch(/check.?out|clone/i)
+    expect(workerPrompt).toMatch(/repo/i)
+  })
+})


### PR DESCRIPTION
## Summary

- Adds `src/server/prompts/supervisor.ts` exporting `supervisorPrompt` — instructs the Supervisor to receive the issue dependency graph, assign workers in dependency order, listen on `epik.supervisor`, merge PRs, reassign stuck workers, and declare done via `nats_publish`.
- Adds `src/server/prompts/worker.ts` exporting `workerPrompt` — instructs each Worker to wait for an assignment, clear context between assignments, check out the repo, implement with TDD (`npm test` red/green), run `npm run lint` and `npm test` before opening a PR, and report completion to `epik.supervisor` via `nats_publish`. Embeds full `ARCHITECTURE.md` for codebase context.
- Adds `src/tests/prompts.test.ts` with 16 keyword-sanity tests covering all required prompt content.

## Test plan

- [x] All 99 tests pass (`npm test`)
- [x] No lint errors (`npm run lint`)
- [x] Prettier formatting clean (`npm run format`)
- [x] `supervisorPrompt` includes: `nats_publish`, `epik.supervisor`, assign/worker, merge/PR/close, stuck/reassign, done/all issues
- [x] `workerPrompt` includes: `nats_publish`, `epik.supervisor`, TDD, `npm run lint`, `npm test`, PR, clear context, check out/clone repo

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)