### PR TITLE
feat: add useAgentEvents hook (src/client/useAgentEvents.ts)

### DIFF
--- a/src/client/useAgentEvents.test.ts
+++ b/src/client/useAgentEvents.test.ts
@@ -1,0 +1,217 @@
+import { renderHook, act } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { useAgentEvents } from './useAgentEvents'
+import type { AgentId, PoolState, ServerMessage } from './types'
+
+// ---------------------------------------------------------------------------
+// Mock WebSocket
+// ---------------------------------------------------------------------------
+
+class MockWebSocket {
+  static instances: MockWebSocket[] = []
+
+  url: string
+  readyState: number = WebSocket.CONNECTING
+  onopen: (() => void) | null = null
+  onmessage: ((event: { data: string }) => void) | null = null
+  onclose: (() => void) | null = null
+  onerror: ((event: unknown) => void) | null = null
+
+  constructor(url: string) {
+    this.url = url
+    MockWebSocket.instances.push(this)
+  }
+
+  open() {
+    this.readyState = WebSocket.OPEN
+    this.onopen?.()
+  }
+
+  receive(data: string) {
+    this.onmessage?.({ data })
+  }
+
+  close() {
+    this.readyState = WebSocket.CLOSED
+    this.onclose?.()
+  }
+
+  send = vi.fn()
+}
+
+// ---------------------------------------------------------------------------
+// Mock fetch
+// ---------------------------------------------------------------------------
+
+const mockFetch = vi.fn().mockResolvedValue({ ok: true })
+
+// ---------------------------------------------------------------------------
+// Setup / teardown
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  MockWebSocket.instances = []
+  vi.stubGlobal('WebSocket', MockWebSocket)
+  vi.stubGlobal('fetch', mockFetch)
+  mockFetch.mockClear()
+  vi.useFakeTimers()
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  vi.useRealTimers()
+})
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('useAgentEvents', () => {
+  it('connects to WebSocket on mount', () => {
+    renderHook(() => useAgentEvents())
+    expect(MockWebSocket.instances).toHaveLength(1)
+    expect(MockWebSocket.instances[0].url).toBe('/ws')
+  })
+
+  it('pool updates when a pool_state message arrives', () => {
+    const { result } = renderHook(() => useAgentEvents())
+    const ws = MockWebSocket.instances[0]
+
+    act(() => {
+      ws.open()
+    })
+
+    const pool: PoolState = [
+      { id: 'supervisor', role: 'supervisor', status: 'idle', sessionId: undefined },
+      { id: 'worker-0', role: 'worker', status: 'busy', sessionId: 'abc' },
+    ]
+    const msg: ServerMessage = { type: 'pool_state', pool }
+
+    act(() => {
+      ws.receive(JSON.stringify(msg))
+    })
+
+    expect(result.current.pool).toEqual(pool)
+  })
+
+  it('events accumulates agent_event messages per agent', () => {
+    const { result } = renderHook(() => useAgentEvents())
+    const ws = MockWebSocket.instances[0]
+
+    act(() => {
+      ws.open()
+    })
+
+    const agentId: AgentId = 'worker-0'
+    const msg: ServerMessage = {
+      type: 'agent_event',
+      agentId,
+      event: { kind: 'text_delta', text: 'Hello' },
+    }
+
+    act(() => {
+      ws.receive(JSON.stringify(msg))
+    })
+
+    expect(result.current.events[agentId]).toHaveLength(1)
+    expect(result.current.events[agentId][0]).toEqual({ kind: 'text_delta', text: 'Hello' })
+  })
+
+  it('accumulates multiple events per agent in order', () => {
+    const { result } = renderHook(() => useAgentEvents())
+    const ws = MockWebSocket.instances[0]
+
+    act(() => {
+      ws.open()
+    })
+
+    const agentId: AgentId = 'supervisor'
+    const msgs: ServerMessage[] = [
+      { type: 'agent_event', agentId, event: { kind: 'text_delta', text: 'First' } },
+      { type: 'agent_event', agentId, event: { kind: 'text_delta', text: 'Second' } },
+      { type: 'agent_event', agentId, event: { kind: 'turn_end' } },
+    ]
+
+    act(() => {
+      for (const msg of msgs) ws.receive(JSON.stringify(msg))
+    })
+
+    expect(result.current.events[agentId]).toHaveLength(3)
+    expect(result.current.events[agentId][2]).toEqual({ kind: 'turn_end' })
+  })
+
+  it('keeps events for different agents separate', () => {
+    const { result } = renderHook(() => useAgentEvents())
+    const ws = MockWebSocket.instances[0]
+
+    act(() => {
+      ws.open()
+    })
+
+    const m0: ServerMessage = {
+      type: 'agent_event',
+      agentId: 'worker-0',
+      event: { kind: 'text_delta', text: 'Worker0' },
+    }
+    const m1: ServerMessage = {
+      type: 'agent_event',
+      agentId: 'worker-1',
+      event: { kind: 'text_delta', text: 'Worker1' },
+    }
+
+    act(() => {
+      ws.receive(JSON.stringify(m0))
+      ws.receive(JSON.stringify(m1))
+    })
+
+    expect(result.current.events['worker-0']).toHaveLength(1)
+    expect(result.current.events['worker-1']).toHaveLength(1)
+    expect(result.current.events['worker-0'][0]).toEqual({ kind: 'text_delta', text: 'Worker0' })
+    expect(result.current.events['worker-1'][0]).toEqual({ kind: 'text_delta', text: 'Worker1' })
+  })
+
+  it('sendMessage POSTs to /api/message', async () => {
+    const { result } = renderHook(() => useAgentEvents())
+
+    await act(async () => {
+      result.current.sendMessage('worker-0', 'Hello agent')
+    })
+
+    expect(mockFetch).toHaveBeenCalledWith('/api/message', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ agentId: 'worker-0', text: 'Hello agent' }),
+    })
+  })
+
+  it('interrupt POSTs to /api/interrupt', async () => {
+    const { result } = renderHook(() => useAgentEvents())
+
+    await act(async () => {
+      result.current.interrupt('supervisor')
+    })
+
+    expect(mockFetch).toHaveBeenCalledWith('/api/interrupt', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ agentId: 'supervisor' }),
+    })
+  })
+
+  it('reconnects after disconnect', () => {
+    renderHook(() => useAgentEvents())
+    const ws0 = MockWebSocket.instances[0]
+
+    act(() => {
+      ws0.open()
+      ws0.close()
+    })
+
+    // Advance time past reconnect delay
+    act(() => {
+      vi.advanceTimersByTime(2000)
+    })
+
+    expect(MockWebSocket.instances).toHaveLength(2)
+  })
+})

--- a/src/client/useAgentEvents.ts
+++ b/src/client/useAgentEvents.ts
@@ -1,0 +1,85 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import type { AgentEvent, AgentId, PoolState, ServerMessage } from './types'
+
+const RECONNECT_DELAY_MS = 1000
+
+export interface AgentEventsState {
+  events: Record<AgentId, AgentEvent[]>
+  pool: PoolState
+  sendMessage: (agentId: AgentId, text: string) => void
+  interrupt: (agentId: AgentId) => void
+}
+
+export function useAgentEvents(): AgentEventsState {
+  const [events, setEvents] = useState<Record<AgentId, AgentEvent[]>>({
+    supervisor: [],
+    'worker-0': [],
+    'worker-1': [],
+    'worker-2': [],
+  })
+  const [pool, setPool] = useState<PoolState>([])
+  const wsRef = useRef<WebSocket | null>(null)
+  const reconnectTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  useEffect(() => {
+    let active = true
+
+    function connect() {
+      if (!active) return
+      const ws = new WebSocket('/ws')
+      wsRef.current = ws
+
+      ws.onmessage = (event: MessageEvent<string>) => {
+        let msg: ServerMessage
+        try {
+          msg = JSON.parse(event.data) as ServerMessage
+        } catch {
+          return
+        }
+
+        if (msg.type === 'pool_state') {
+          setPool(msg.pool)
+        } else if (msg.type === 'agent_event') {
+          const { agentId, event: agentEvent } = msg
+          setEvents((prev) => ({
+            ...prev,
+            [agentId]: [...(prev[agentId] ?? []), agentEvent],
+          }))
+        }
+      }
+
+      ws.onclose = () => {
+        if (!active) return
+        reconnectTimer.current = setTimeout(connect, RECONNECT_DELAY_MS)
+      }
+    }
+
+    connect()
+
+    return () => {
+      active = false
+      if (reconnectTimer.current !== null) {
+        clearTimeout(reconnectTimer.current)
+      }
+      wsRef.current?.close()
+    }
+  }, [])
+
+  const sendMessage = useCallback((agentId: AgentId, text: string) => {
+    void fetch('/api/message', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ agentId, text }),
+    })
+  }, [])
+
+  const interrupt = useCallback((agentId: AgentId) => {
+    void fetch('/api/interrupt', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ agentId }),
+    })
+  }, [])
+
+  return { events, pool, sendMessage, interrupt }
+}


### PR DESCRIPTION
## Summary

- Implements `src/client/useAgentEvents.ts` — a React hook that maintains a live WebSocket connection to the server
- Connects to `/ws` (proxied by Vite to `ws://localhost:3001/ws`) on mount and reconnects automatically after disconnect
- Parses incoming `ServerMessage` envelopes and dispatches to two pieces of state:
  - `events: Record<AgentId, AgentEvent[]>` — accumulates events per agent
  - `pool: PoolState` — updated on every `pool_state` message
- Exposes `sendMessage(agentId, text)` (POSTs to `/api/message`) and `interrupt(agentId)` (POSTs to `/api/interrupt`)

## Technical decisions

- Reconnect logic lives inside `useEffect` as a local `connect()` function, which avoids the react-hooks/immutability lint error that would arise from a self-referential `useCallback`
- An `active` guard prevents state updates and reconnects after the component unmounts

## Testing approach

- 8 tests in `src/client/useAgentEvents.test.ts` using `@testing-library/react`'s `renderHook`
- WebSocket mocked via `vi.stubGlobal('WebSocket', MockWebSocket)`; `fetch` mocked via `vi.stubGlobal('fetch', mockFetch)`
- Fake timers (`vi.useFakeTimers`) used to verify reconnect behaviour without real delays

## Closes

Closes #10