### PR TITLE
fix: run NATS integration tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,11 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    services:
+      nats:
+        image: nats:latest
+        ports:
+          - 4222:4222
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -20,7 +25,7 @@ jobs:
           key: node-modules-${{ hashFiles('package-lock.json') }}
       - if: steps.cache-node-modules.outputs.cache-hit != 'true'
         run: npm ci
-      - run: npm test -- --coverage --exclude 'src/tests/*.integration.test.ts'
+      - run: npm test -- --coverage
       - uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/src/tests/nats.integration.test.ts
+++ b/src/tests/nats.integration.test.ts
@@ -1,9 +1,14 @@
-import { describe, it, expect, afterAll } from 'vitest'
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest'
 
 // These tests require a running nats-server on localhost:4222
 // Run: nats-server &
 
 describe('nats module', () => {
+  beforeAll(() => {
+    // Reset the module registry so this file always imports the real nats
+    // module, never a vi.doMock() stub installed by another test file.
+    vi.resetModules()
+  })
   it('exports topic constants matching architecture spec', async () => {
     const { TOPIC_SUPERVISOR, TOPIC_WORKER_0, TOPIC_WORKER_1, TOPIC_WORKER_2, TOPIC_LOG } =
       await import('../server/nats.ts')


### PR DESCRIPTION
## Summary

- Add a `nats:latest` service container to the CI workflow so the test runner has a real NATS server on port 4222
- Remove the `--exclude` flag that was suppressing integration tests from running in CI
- Add `vi.resetModules()` in `beforeAll` to ensure the integration test file always imports the real `nats` module, never a `vi.doMock()` stub leaked from another test file

## Test plan

- All 156 tests pass locally including the 4 NATS integration tests
- Integration tests now exercise a real TCP connection to NATS rather than silently passing via a mocked module