### PR TITLE
fix: prevent page-level scroll on initial render

### DIFF
--- a/src/client/App.test.tsx
+++ b/src/client/App.test.tsx
@@ -286,6 +286,14 @@ describe('App', () => {
     }
   })
 
+  it('does not scroll on initial load', () => {
+    const spy = vi.fn()
+    HTMLElement.prototype.scrollIntoView = spy
+    render(<App />)
+    expect(spy).not.toHaveBeenCalled()
+    HTMLElement.prototype.scrollIntoView = () => {}
+  })
+
   it('unmounts cleanly when fetch rejects after unmount (cancelled flag suppresses setGraph)', async () => {
     // Make fetch reject after a delay
     let rejectFetch!: (err: Error) => void

--- a/src/client/ConsolePane.test.tsx
+++ b/src/client/ConsolePane.test.tsx
@@ -191,6 +191,32 @@ describe('ConsolePane', () => {
     expect(onSend).toHaveBeenCalledWith('Direct message')
   })
 
+  it('does not scroll on initial render with no messages', () => {
+    const spy = vi.fn()
+    HTMLElement.prototype.scrollIntoView = spy
+    render(<ConsolePane agentId={agentId} events={[]} onSend={noop} onInterrupt={noop} />)
+    expect(spy).not.toHaveBeenCalled()
+    HTMLElement.prototype.scrollIntoView = () => {}
+  })
+
+  it('scrolls to bottom when a message arrives', () => {
+    const spy = vi.fn()
+    HTMLElement.prototype.scrollIntoView = spy
+    const { rerender } = render(
+      <ConsolePane agentId={agentId} events={[]} onSend={noop} onInterrupt={noop} />,
+    )
+    rerender(
+      <ConsolePane
+        agentId={agentId}
+        events={[{ kind: 'text_delta', text: 'Hello' }]}
+        onSend={noop}
+        onInterrupt={noop}
+      />,
+    )
+    expect(spy).toHaveBeenCalled()
+    HTMLElement.prototype.scrollIntoView = () => {}
+  })
+
   it('enqueues a second message when agent is busy', async () => {
     const onSend = vi.fn()
     const user = userEvent.setup()

--- a/src/client/ConsolePane.tsx
+++ b/src/client/ConsolePane.tsx
@@ -251,6 +251,7 @@ export default function ConsolePane(props: ConsolePaneProps) {
   const processedCountRef = useRef(0)
 
   useEffect(() => {
+    if (messages.length === 0) return
     bottomRef.current?.scrollIntoView({ behavior: 'smooth' })
   }, [messages])
 

--- a/src/index.css
+++ b/src/index.css
@@ -8,6 +8,13 @@ body {
   margin: 0;
 }
 
+html,
+body,
+#root {
+  height: 100%;
+  overflow: hidden;
+}
+
 /* Override hljs theme based on html[data-theme] */
 :root[data-theme='dark'] .hljs {
   color: #c9d1d9;


### PR DESCRIPTION
## Summary

- Add `html, body, #root { height: 100%; overflow: hidden }` to `index.css` so the browser never renders a page-level scrollbar; all scrolling is delegated to the ConsolePane `messageList` div (which already has `overflowY: auto`)
- Guard the `scrollIntoView` effect in `ConsolePane` to skip when `messages` is empty, preventing it from scrolling the page body on initial mount
- Add tests for both fixes: `scrollIntoView` is not called on empty mount, is called when a message arrives, and is not called during `App` initial load

## Root causes fixed

Two bugs caused the toolbar to be hidden on load and the scrollbar to misbehave:

1. Without `overflow: hidden` on `html`/`body`, the browser rendered a scrollable page body. The `react-force-graph-2d` canvas initial render caused overflow, producing a non-functional page scrollbar.
2. The `scrollIntoView` effect in `ConsolePane` fired on empty initial mount, scrolling the page body instead of the message list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)