### PR TITLE
fix: move NATS SIGINT handler out of module scope to prevent listener leak

### DIFF
--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -22,7 +22,7 @@ import { resolve } from 'path'
 import { fileURLToPath } from 'url'
 import type { AgentId, ServerMessage } from '../client/types.ts'
 import { createAgentPool } from './agentPool.ts'
-import { getNatsConnection, TOPIC_SUPERVISOR } from './nats.ts'
+import { getNatsConnection, registerShutdownHandler, TOPIC_SUPERVISOR } from './nats.ts'
 import { loadIssueGraph } from './github.ts'
 
 export const app = express()
@@ -201,6 +201,7 @@ wss.on('connection', async (ws) => {
 
 /* v8 ignore start */
 if (process.argv[1] === new URL(import.meta.url).pathname) {
+  registerShutdownHandler()
   const PORT = parseInt(process.env['PORT'] ?? '3001', 10)
   server.listen(PORT, () => {
     console.log(`Server listening on port ${PORT}`)

--- a/src/server/nats.ts
+++ b/src/server/nats.ts
@@ -57,7 +57,17 @@ export async function closeNatsConnection(): Promise<void> {
   }
 }
 
-process.on('SIGINT', async () => {
-  await closeNatsConnection()
-  process.exit(0)
-})
+/**
+ * Registers a SIGINT handler that drains the NATS connection before the
+ * process exits, ensuring in-flight messages are not dropped.
+ *
+ * Call this once at server startup. It is intentionally not called at module
+ * load time so that test suites that repeatedly re-import this module do not
+ * accumulate duplicate listeners.
+ */
+export function registerShutdownHandler(): void {
+  process.on('SIGINT', async () => {
+    await closeNatsConnection()
+    process.exit(0)
+  })
+}

--- a/src/tests/nats.test.ts
+++ b/src/tests/nats.test.ts
@@ -177,7 +177,10 @@ describe('nats module (unit)', () => {
 
   it('SIGINT handler closes the connection and calls process.exit', async () => {
     const mockConn = makeMockConn()
-    const { getNatsConnection } = await makeNatsModule(vi.fn(async () => mockConn))
+    const { getNatsConnection, registerShutdownHandler } = await makeNatsModule(
+      vi.fn(async () => mockConn),
+    )
+    registerShutdownHandler()
     await getNatsConnection()
 
     // Spy on process.exit to prevent the test process from actually exiting.


### PR DESCRIPTION
## Summary

- Extracted the `SIGINT` shutdown handler from module-level code in `nats.ts` into an exported `registerShutdownHandler()` function
- Called `registerShutdownHandler()` once at server startup in `index.ts`, preserving graceful drain-on-exit behavior in production
- Updated the SIGINT unit test to explicitly call `registerShutdownHandler()` before emitting the signal

## Background

The NATS module previously registered a `process.on('SIGINT', ...)` handler at module load time. The unit tests use `vi.resetModules()` + dynamic `import()` to isolate each test, which re-executes the module body on every import. This registered a new SIGINT listener per test, triggering a `MaxListenersExceededWarning` (limit: 10) at the start of every test run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)