### PR TITLE
chore: rename package from builder to console and bump version to 0.1.0

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,6 +1,6 @@
-# Builder — Architecture
+# Console — Architecture
 
-Builder is a single-page multi-agent build console. Given a GitHub repository
+Console is a single-page multi-agent build console. Given a GitHub repository
 with open issues, it autonomously implements the issues using a team of Claude
 Code agents coordinated over NATS.
 
@@ -222,7 +222,7 @@ The Express server runs from TypeScript source via `tsx watch` on `:3001`.
    runtime dependencies (`express`, `ws`, `nats`, `@anthropic-ai/claude-agent-sdk`)
    as externals resolved from `node_modules`
 
-**Docker** (`docker compose up --build`): runs the production build in a builder
+**Docker** (`docker compose up --build`): runs the production build in a build
 stage, then copies only `dist/` into a lean production image. `.dockerignore`
 excludes the host `node_modules` so the container always installs fresh
 Linux-compatible binaries. Layer caching means `npm ci` and `gh` installation
@@ -249,7 +249,7 @@ exists locally, preventing any test-ordering sensitivity to local build state.
 
 ## Reuse from Epik
 
-| Epik source                   | Builder destination             | Changes                            |
+| Epik source                   | Console destination             | Changes                            |
 | ----------------------------- | ------------------------------- | ---------------------------------- |
 | `src/renderer/chatReducer.ts` | `src/client/chatReducer.ts`     | None                               |
 | `src/renderer/theme.ts`       | `src/client/theme.ts`           | Drop `PersonaId` import            |

--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
-# Builder
+# Console
 
 [![CI](https://github.com/epik-agent/console/actions/workflows/ci.yml/badge.svg)](https://github.com/epik-agent/console/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/epik-agent/console/graph/badge.svg?token=1V88WCNEGN)](https://codecov.io/gh/epik-agent/console)
 
-Builder is a multi-agent build console. Give it a GitHub repository with open
+Console is a multi-agent build console. Give it a GitHub repository with open
 issues and it autonomously implements them using a team of Claude Code agents
 coordinated over NATS.
 
 ## Quick start with Docker
 
-The easiest way to run Builder is with Docker Compose, which starts NATS and
+The easiest way to run Console is with Docker Compose, which starts NATS and
 the application server automatically.
 
 ### Without GitHub access
@@ -32,7 +32,7 @@ This pulls your token from the `gh` CLI keyring automatically
 (`GH_TOKEN=$(gh auth token) docker compose up`). Requires `gh auth login`
 to have been run at least once.
 
-Open http://localhost:5173 and enter `epik-agent/builder` (or any
+Open http://localhost:5173 and enter `epik-agent/console` (or any
 `owner/repo`) in the toolbar. Click **Load** to fetch the issue graph.
 
 ### What you should see
@@ -90,7 +90,7 @@ TypeScript source via `tsx watch` on `:3001`.
    left as externals so they are resolved from `node_modules` at runtime
 
 **Docker** (`docker compose up --build`): runs the production build inside the
-builder stage, then copies only `dist/` into the lean production image.
+build stage, then copies only `dist/` into the lean production image.
 `node_modules` on the host is excluded via `.dockerignore` so the container
 always installs fresh Linux-compatible binaries.
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "builder",
+  "name": "console",
   "private": true,
-  "version": "0.0.0",
+  "version": "0.1.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary

- Rename package `name` in `package.json` from `"builder"` to `"console"`
- Bump version from `0.0.0` to `0.1.0`
- Update all documentation references in `README.md` and `ARCHITECTURE.md` to use "Console" instead of "Builder"

🤖 Generated with [Claude Code](https://claude.com/claude-code)