### PR TITLE
feat: auto-start NATS via Docker for local dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,9 @@
   "version": "0.1.0",
   "type": "module",
   "scripts": {
-    "dev": "vite",
-    "dev:full": "concurrently \"vite\" \"npm run server\"",
+    "nats": "bash scripts/ensure-nats.sh",
+    "dev": "npm run nats && vite",
+    "dev:full": "npm run nats && concurrently \"vite\" \"npm run server\"",
     "server": "tsx watch src/server/index.ts",
     "build": "tsc -b && vite build && npm run build:server",
     "build:client": "vite build",
@@ -14,7 +15,7 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "preview": "vite preview",
-    "test": "vitest run"
+    "test": "npm run nats && vitest run"
   },
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.2.49",

--- a/scripts/ensure-nats.sh
+++ b/scripts/ensure-nats.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PORT=4222
+CONTAINER_NAME=epik-nats
+IMAGE=nats:latest
+TIMEOUT=10
+
+# Port already open → NATS is running (covers CI service container case).
+if nc -z localhost "$PORT" 2>/dev/null; then
+  echo "NATS already reachable on port $PORT"
+  exit 0
+fi
+
+# Container not yet running → start it.
+if ! docker ps --format '{{.Names}}' | grep -q "^${CONTAINER_NAME}$"; then
+  echo "Starting NATS container ($IMAGE)..."
+  docker run -d --name "$CONTAINER_NAME" -p "${PORT}:4222" --rm "$IMAGE"
+fi
+
+# Wait for NATS to accept connections.
+echo "Waiting for NATS on port $PORT..."
+for i in $(seq 1 "$TIMEOUT"); do
+  if nc -z localhost "$PORT" 2>/dev/null; then
+    echo "NATS ready."
+    exit 0
+  fi
+  sleep 1
+done
+
+echo "ERROR: Timed out waiting for NATS on port $PORT" >&2
+exit 1


### PR DESCRIPTION
## Summary

- Adds `scripts/ensure-nats.sh` — checks if port 4222 is already reachable (exits immediately when running in CI), otherwise starts an `epik-nats` Docker container and polls until NATS is ready (up to 10 s)
- Adds a `nats` npm script as a standalone entry point for the shell script
- Prepends `npm run nats &&` to `dev`, `dev:full`, and `test` so `npm run dev` is the single on-switch for local development with no manual NATS setup required
- CI is unaffected — the GitHub Actions NATS service container opens port 4222 before any step runs, causing the script to exit immediately without touching Docker

## Test plan

- Run `npm run dev:full` on a fresh machine — confirm `epik-nats` appears in `docker ps` and Vite + server start
- Run `npm run nats` twice — second call should exit immediately with "NATS already reachable"
- Run `npm test` locally — integration tests pass against live NATS
- Push branch — CI green with no changes to `ci.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)