### PR TITLE
feat: remove italic styling from wordmark

### DIFF
--- a/src/client/App.test.tsx
+++ b/src/client/App.test.tsx
@@ -145,7 +145,7 @@ describe('App', () => {
   describe('toolbar structure', () => {
     it('renders the brand mark and name', () => {
       render(<App />)
-      expect(screen.getByText(/epi/)).toBeInTheDocument()
+      expect(screen.getByText('Epik')).toBeInTheDocument()
     })
 
     it('renders a connection badge', () => {

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -185,9 +185,7 @@ export default function App() {
             <circle cx="8" cy="17" r="2" fill="currentColor" />
             <circle cx="14" cy="17" r="1.6" fill="var(--brand-accent-base)" opacity="0.7" />
           </svg>
-          <span>
-            Epik
-          </span>
+          <span>Epik</span>
         </div>
 
         <form onSubmit={handleRepoSubmit} className="toolbar-form">


### PR DESCRIPTION
Replace the typeset "epi𝑘" wordmark (which rendered the *k* in italic) with plain "Epik" text.