### PR TITLE
fix: specify lcov.info path for Codecov upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,3 +29,4 @@ jobs:
       - uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          files: coverage/lcov.info


### PR DESCRIPTION
## Summary

- Explicitly set `files: coverage/lcov.info` in the Codecov action so the uploader knows where vitest writes the lcov report
- Fixes Codecov receiving no coverage data since commit 5586bd4 — the CLI's auto-discovery was not finding the file at its non-standard path

🤖 Generated with [Claude Code](https://claude.com/claude-code)