### PR TITLE
fix: generate coverage report for Codecov upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-pnpm
-      - run: pnpm test -- --coverage
+      - run: pnpm exec vitest run --coverage
       - uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## Summary

- Replace `pnpm test -- --coverage` with `pnpm exec vitest run --coverage` in CI
- The `--` separator caused pnpm to pass `--coverage` as a passthrough arg to the script rather than a vitest flag, so vitest never wrote `coverage/lcov.info` to disk
- Codecov was finding 0 coverage files and silently failing on every CI run since the integration was added

🤖 Generated with [Claude Code](https://claude.com/claude-code)