### PR TITLE
fix: render IssueGraph nodes as labeled boxes, fix overflow, add GitHub links

### DIFF
--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -222,7 +222,7 @@ export default function App() {
 
       {/* Top 50 %: Issue graph */}
       <div className="pane-top">
-        <IssueGraph graph={graph} events={events} agentIssueMap={agentIssueMap} />
+        <IssueGraph graph={graph} events={events} agentIssueMap={agentIssueMap} repo={repo} />
       </div>
 
       {/* Bottom 50 %: Agent tabs */}


### PR DESCRIPTION
## Summary

- Nodes now render as rounded rectangles showing the issue number (`#N`) and truncated title, replacing the plain yellow dots
- Graph canvas is sized to its container div via `ResizeObserver` + explicit `width`/`height` props, preventing overflow beyond the top pane and eliminating pointer-event blocking on the rest of the page
- Clicking a node opens the corresponding GitHub issue URL (`https://github.com/<owner>/<repo>/issues/<N>`) in a new tab; `repo` prop is now passed from `App` to `IssueGraph`
- `nodePointerAreaPaint` provides a rectangular hit-test area matching the custom node shape
- Added `ResizeObserver` stub to `src/test-setup.ts` for jsdom compatibility
- Extended the `ForceGraph2D` mock and added 10 new tests covering custom node rendering, container-driven sizing, and GitHub link behaviour

## Test plan

- All 285 tests pass (`pnpm test`)
- Manual: load a repo, confirm the graph stays within the top pane, nodes show `#N` + title as rounded boxes, clicking a node opens the GitHub issue in a new tab, toolbar and bottom pane remain fully interactive

Closes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)