### PR TITLE
feat: add busy spinner states and load button validation

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -352,6 +352,30 @@ body {
   color: var(--brand-text-primary);
 }
 
+.btn--busy {
+  position: relative;
+  color: transparent !important;
+  pointer-events: none;
+}
+
+.btn--busy::after {
+  content: '';
+  position: absolute;
+  width: 12px;
+  height: 12px;
+  border: 2px solid currentColor;
+  border-top-color: transparent;
+  border-radius: 50%;
+  animation: btn-spin 0.7s linear infinite;
+  color: inherit;
+}
+
+@keyframes btn-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
 /* ---- Connection status ---- */
 .connection-badge {
   display: inline-flex;


### PR DESCRIPTION
## Summary

- Load button is disabled when the repo input is empty or contains no slash (enforces `owner/repo` format)
- Load button shows a rotating spinner while the graph fetch is in flight and re-enables on completion or error
- Start button shows a spinner after click and clears automatically once the WebSocket `pool_state` confirms `running: true`
- Stop button shows a spinner after click and clears once `pool_state` confirms `running: false`
- Safety timeouts (10 s) clear stuck spinners if no WebSocket confirmation arrives
- Added `.btn--busy` CSS modifier with a 12 px rotating spinner via `::after` pseudo-element
- 8 new tests covering disabled states, busy states, and pending clear-on-transition behaviour

## Implementation notes

Pending state for Start/Stop is derived rather than effect-driven: `startPending = startClickedWhileNotRunning && !running`, which automatically clears when `running` flips without needing a `useEffect` with synchronous `setState` (which the `react-hooks/set-state-in-effect` ESLint rule forbids).

🤖 Generated with [Claude Code](https://claude.com/claude-code)