### PR TITLE
feat: add stop script to kill dev processes

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,19 +57,20 @@ Open http://localhost:5173/?repo=owner/repo.
 
 ### Scripts
 
-| Script                  | Description                                       |
-| ----------------------- | ------------------------------------------------- |
-| `pnpm run dev`          | Vite dev server + Express via tsx (hot reload)    |
-| `pnpm run server`       | Express server only (tsx watch)                   |
-| `pnpm run build`        | Type-check + Vite frontend bundle + server bundle |
-| `pnpm run build:server` | esbuild server bundle only → `dist/server.js`     |
-| `pnpm run lint`         | ESLint + tsc type-check                           |
-| `pnpm run format`       | Prettier (write)                                  |
-| `pnpm run format:check` | Prettier (check only)                             |
-| `pnpm test`             | All tests (single run)                            |
-| `pnpm test:unit`        | Client + unit tests (no services needed)          |
-| `pnpm test:integration` | Integration tests (requires NATS)                 |
-| `pnpm test:coverage`    | All tests with coverage report                    |
+| Script                  | Description                                         |
+| ----------------------- | --------------------------------------------------- |
+| `pnpm run dev`          | Vite dev server + Express via tsx (hot reload)      |
+| `pnpm run stop`         | Kill Vite (:5173) and Express (:3001) dev processes |
+| `pnpm run server`       | Express server only (tsx watch)                     |
+| `pnpm run build`        | Type-check + Vite frontend bundle + server bundle   |
+| `pnpm run build:server` | esbuild server bundle only → `dist/server.js`       |
+| `pnpm run lint`         | ESLint + tsc type-check                             |
+| `pnpm run format`       | Prettier (write)                                    |
+| `pnpm run format:check` | Prettier (check only)                               |
+| `pnpm test`             | All tests (single run)                              |
+| `pnpm test:unit`        | Client + unit tests (no services needed)            |
+| `pnpm test:integration` | Integration tests (requires NATS)                   |
+| `pnpm test:coverage`    | All tests with coverage report                      |
 
 ## Testing
 

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "concurrently \"vite\" \"npm run server\"",
+    "stop": "lsof -ti:3001 -ti:5173 | xargs kill -9 2>/dev/null; true",
     "server": "tsx watch src/server/index.ts",
     "build": "tsc -b && vite build && npm run build:server",
     "build:client": "vite build",


### PR DESCRIPTION
## Summary

- Add `pnpm run stop` script that kills Vite (:5173) and Express (:3001) dev processes by PID using `lsof` + `kill -9`, leaving the NATS Docker container (port 4222) untouched
- Script uses `2>/dev/null; true` to exit 0 cleanly when no processes are running
- Document `pnpm run stop` in the README Scripts table

## Test plan

- Run `pnpm run dev`, then in another terminal run `pnpm run stop`
- Confirm `lsof -i:3001 -i:5173` returns nothing
- Run `pnpm run stop` again with nothing running — should exit 0 with no errors
- Confirm NATS is unaffected: `lsof -i:4222` still shows the Docker process

🤖 Generated with [Claude Code](https://claude.com/claude-code)