### PR TITLE
fix: replace npm run with pnpm run in scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,10 +4,10 @@
   "version": "0.1.0",
   "type": "module",
   "scripts": {
-    "dev": "concurrently \"vite\" \"npm run server\"",
+    "dev": "concurrently \"vite\" \"pnpm run server\"",
     "stop": "lsof -ti:3001 -ti:5173 | xargs kill -9 2>/dev/null; true",
     "server": "tsx watch src/server/index.ts",
-    "build": "tsc -b && vite build && npm run build:server",
+    "build": "tsc -b && vite build && pnpm run build:server",
     "build:client": "vite build",
     "build:server": "esbuild src/server/index.ts --bundle --platform=node --format=esm --outfile=dist/server.js --external:@anthropic-ai/claude-agent-sdk --external:nats --external:express --external:ws",
     "lint": "tsc --noEmit && eslint .",


### PR DESCRIPTION
## Summary

- Replaced `npm run server` with `pnpm run server` in the `dev` script
- Replaced `npm run build:server` with `pnpm run build:server` in the `build` script

The project uses pnpm as its package manager. When pnpm runs scripts, it injects its own config as `npm_config_*` environment variables. Calling `npm run` from within a pnpm-run script caused npm to pick up pnpm-specific env vars (`_jsr-registry`, `npm-globalconfig`, `verify-deps-before-run`) and emit warnings about unknown config keys. Using `pnpm run` throughout keeps everything within pnpm's context and eliminates these warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)