### PR TITLE
fix: issue graph nodes render as labeled rectangles with arrows

### DIFF
--- a/src/client/IssueGraph.test.tsx
+++ b/src/client/IssueGraph.test.tsx
@@ -35,7 +35,7 @@ vi.mock('react-force-graph-2d', () => ({
         color: string,
         ctx: CanvasRenderingContext2D,
       ) => void
-      nodeCanvasObjectMode?: string
+      nodeCanvasObjectMode?: string | ((node: NodeObject) => string)
       onNodeClick?: (node: NodeObject, event: MouseEvent) => void
       width?: number
       height?: number
@@ -392,9 +392,10 @@ describe('IssueGraph', () => {
 
   // ── Custom node rendering ─────────────────────────────────────────────────
 
-  it('passes nodeCanvasObjectMode="replace" to ForceGraph', () => {
+  it('passes nodeCanvasObjectMode as a function returning "replace" to ForceGraph', () => {
     render(<IssueGraph graph={sampleGraph} events={noEvents} />)
-    expect(capturedNodeCanvasObjectMode).toBe('replace')
+    expect(typeof capturedNodeCanvasObjectMode).toBe('function')
+    expect((capturedNodeCanvasObjectMode as (node: NodeObject) => string)({})).toBe('replace')
   })
 
   it('passes a nodeCanvasObject function to ForceGraph', () => {

--- a/src/client/IssueGraph.tsx
+++ b/src/client/IssueGraph.tsx
@@ -219,7 +219,7 @@ export default function IssueGraph({ graph, events, agentIssueMap, repo }: Issue
         nodeLabel="label"
         nodeColor={nodeColor}
         nodeCanvasObject={nodeCanvasObject}
-        nodeCanvasObjectMode="replace"
+        nodeCanvasObjectMode={() => 'replace'}
         nodePointerAreaPaint={nodePointerAreaPaint}
         onNodeClick={onNodeClick}
         width={dimensions.width}


### PR DESCRIPTION
## Summary

Fixes #80. Issue graph nodes were rendering as plain yellow circles with no text and no directional arrows.

- `react-force-graph-2d` passes all props through the `accessor-fn` library, which interprets a plain string as a property name to look up on each node object. Passing `nodeCanvasObjectMode="replace"` caused `accessor-fn` to evaluate `node["replace"]` → `undefined` for every node, so the custom `nodeCanvasObject` was never invoked and nodes fell back to the library's default circle rendering.
- Fixed by passing a function `() => 'replace'` instead of the string literal, which `accessor-fn` calls correctly.
- Updated the corresponding test to assert the prop is a function that returns `"replace"` rather than asserting the string value directly.

## Test plan

- All 297 unit tests pass.
- Verified visually in headed Playwright: nodes now render as rounded rectangles with issue number and title; directional arrows appear on links between nodes.