### PR TITLE
feat: separate issue graph edge data from visualization

### DIFF
--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -21,7 +21,7 @@ function isValidRepo(value: string): boolean {
   return t.length > 0 && t.includes('/')
 }
 
-const EMPTY_GRAPH: IssueGraphType = { nodes: [] }
+const EMPTY_GRAPH: IssueGraphType = { nodes: [], edges: [] }
 
 const CONNECTION_LABELS: Record<ConnectionStatus, string> = {
   connected: 'Connected',

--- a/src/client/IssueGraph.test.tsx
+++ b/src/client/IssueGraph.test.tsx
@@ -78,6 +78,10 @@ const sampleGraph: IssueGraphType = {
     },
     { number: 3, title: 'Done bug', state: 'closed', type: 'Bug', external: false, blockedBy: [1] },
   ],
+  edges: [
+    { source: 1, target: 2 },
+    { source: 1, target: 3 },
+  ],
 }
 
 const noEvents: Record<AgentId, AgentEvent[]> = {
@@ -190,6 +194,7 @@ describe('IssueGraph', () => {
       nodes: [
         { number: 1, title: 'Solo', state: 'open', type: null, external: false, blockedBy: [] },
       ],
+      edges: [],
     }
     render(<IssueGraph graph={simpleGraph} events={noEvents} />)
     expect(capturedGraphData!.links).toHaveLength(0)

--- a/src/client/IssueGraph.tsx
+++ b/src/client/IssueGraph.tsx
@@ -23,11 +23,6 @@ interface IssueNode extends NodeObject {
   state: 'open' | 'closed'
 }
 
-interface IssueLink {
-  source: number
-  target: number
-}
-
 interface IssueGraphProps {
   graph: IssueGraphType
   events: Record<AgentId, AgentEvent[]>
@@ -127,9 +122,7 @@ export default function IssueGraph({ graph, events, agentIssueMap, repo }: Issue
     state: n.state,
   }))
 
-  const links: IssueLink[] = graph.nodes.flatMap((n) =>
-    n.blockedBy.map((blocker) => ({ source: blocker, target: n.number })),
-  )
+  const links = graph.edges
 
   const nodeColor = (node: NodeObject): string => {
     const issueNode = node as IssueNode

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -63,9 +63,19 @@ export interface IssueNode {
   blockedBy: number[]
 }
 
+/** A directed edge in the issue dependency graph. */
+export interface IssueEdge {
+  /** Issue number of the blocker (prerequisite). */
+  source: number
+  /** Issue number of the blocked issue (dependent). */
+  target: number
+}
+
 /** The dependency graph for a set of GitHub issues. */
 export interface IssueGraph {
   nodes: IssueNode[]
+  /** Directed edges derived from blockedBy; computed once in github.ts. */
+  edges: IssueEdge[]
 }
 
 // ---------------------------------------------------------------------------

--- a/src/server/github.ts
+++ b/src/server/github.ts
@@ -1,5 +1,5 @@
 import { execFile } from 'child_process'
-import type { IssueGraph, IssueNode } from '../client/types.ts'
+import type { IssueEdge, IssueGraph, IssueNode } from '../client/types.ts'
 
 // ---------------------------------------------------------------------------
 // Types
@@ -150,7 +150,11 @@ export async function loadIssueGraph(
     blockedBy: parseBlockedBy(issue.body),
   }))
 
-  return { nodes }
+  const edges: IssueEdge[] = nodes.flatMap((n) =>
+    n.blockedBy.map((blocker) => ({ source: blocker, target: n.number })),
+  )
+
+  return { nodes, edges }
 }
 
 /**

--- a/src/tests/unit/github.test.ts
+++ b/src/tests/unit/github.test.ts
@@ -202,6 +202,20 @@ describe('github', () => {
       expect(node?.blockedBy).toEqual([5, 6])
     })
 
+    it('derives directed edges from blockedBy lists', async () => {
+      const graph = await loadIssueGraph('owner', 'repo', makeExec(ISSUE_FIXTURE))
+      // node 2 blockedBy [1] → edge { source: 1, target: 2 }
+      // node 3 blockedBy [1, 2] → edges { source: 1, target: 3 }, { source: 2, target: 3 }
+      expect(graph.edges).toContainEqual({ source: 1, target: 2 })
+      expect(graph.edges).toContainEqual({ source: 1, target: 3 })
+      expect(graph.edges).toContainEqual({ source: 2, target: 3 })
+    })
+
+    it('returns empty edges for a graph with no dependencies', async () => {
+      const graph = await loadIssueGraph('owner', 'repo', makeExec([]))
+      expect(graph.edges).toEqual([])
+    })
+
     it('rejects on gh cli error', async () => {
       const exec = makeExecError(new Error('gh: not found'))
       let caught: Error | null = null


### PR DESCRIPTION
## Summary

- Add `IssueEdge` type (`source`, `target`) and `edges: IssueEdge[]` field to `IssueGraph` in `types.ts`
- Move edge derivation from `blockedBy` data into `github.ts` (`loadIssueGraph`), computed once at the data layer
- Simplify `IssueGraph.tsx` by removing the private `IssueLink` type and `flatMap`; the component now consumes `graph.edges` directly
- Update `EMPTY_GRAPH` in `App.tsx` and test fixtures in `IssueGraph.test.tsx` to include `edges`
- Add two new unit tests in `github.test.ts` covering edge derivation from `blockedBy` lists and the empty-graph case
- `github.ts` reaches 100% coverage across all metrics

## Test plan

- `pnpm test` passes (303 tests, 0 failures)
- `pnpm lint` passes with no type errors or lint warnings
- `GET /api/issues` response JSON now includes an `edges` array alongside `nodes`
- IssueGraph renders identically to before (no visual change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)