### PR TITLE
fix: skip WS close() during CONNECTING state in effect cleanup (#85)

### DIFF
--- a/src/client/useAgentEvents.ts
+++ b/src/client/useAgentEvents.ts
@@ -130,7 +130,10 @@ export function useAgentEvents(): AgentEventsState {
       if (reconnectTimer.current !== null) {
         clearTimeout(reconnectTimer.current)
       }
-      wsRef.current?.close()
+      const ws = wsRef.current
+      if (ws && ws.readyState !== WebSocket.CONNECTING) {
+        ws.close()
+      }
     }
   }, [])
 


### PR DESCRIPTION
## Summary

- Guard the WebSocket cleanup in `useAgentEvents` to skip `close()` when `readyState === WebSocket.CONNECTING`
- Eliminates the browser warning "WebSocket is closed before the connection is established" on every page load
- Eliminates the `[vite] ws proxy error: write EPIPE` server log that accompanied it

## Root Cause

React Strict Mode double-invokes effects in development: mount → cleanup → mount again. The cleanup called `ws.close()` unconditionally, which aborts the handshake if the socket is still CONNECTING. This caused the browser to close the socket before the server finished the WS upgrade, producing an EPIPE on the server side and a warning in the browser console on every load.

The fix checks `readyState` before closing — if the socket hasn't finished connecting yet, we leave it alone (the `active` flag set to `false` ensures the second mount's socket takes over).

🤖 Generated with [Claude Code](https://claude.com/claude-code)