### PR TITLE
fix: make issue graph dependency edges and arrows visible (#89)

### DIFF
--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -285,7 +285,13 @@ export default function App() {
             {graph.warning}
           </div>
         )}
-        <IssueGraph graph={graph} events={events} agentIssueMap={agentIssueMap} repo={repo} />
+        <IssueGraph
+          graph={graph}
+          events={events}
+          agentIssueMap={agentIssueMap}
+          repo={repo}
+          theme={theme}
+        />
       </div>
 
       {/* Bottom 50 %: Agent tabs */}

--- a/src/client/theme.ts
+++ b/src/client/theme.ts
@@ -113,7 +113,7 @@ export const themes: { dark: Palette; light: Palette } = {
       closed: '#34d399',
       open: '#f5a623',
       active: '#00e599',
-      link: 'rgba(255, 255, 255, 0.10)',
+      link: 'rgba(255, 255, 255, 0.50)',
     },
   },
   light: {
@@ -157,7 +157,7 @@ export const themes: { dark: Palette; light: Palette } = {
       closed: '#34d399',
       open: '#d4940a',
       active: '#00b377',
-      link: 'rgba(0, 0, 0, 0.08)',
+      link: 'rgba(0, 0, 0, 0.40)',
     },
   },
 }


### PR DESCRIPTION
## Summary

- Add `nodeRelSize={60}` to `ForceGraph2D` so arrowheads are positioned at the edge of the 120px-wide node rectangles instead of buried inside them
- Configure d3 `charge` strength (`-400`) and link `distance` (`200`) via imperative ref so nodes spread apart and link lengths always exceed the arrow-render threshold
- Add `theme` prop to `IssueGraph` and derive all graph colors (including link color) from `palette[theme]` instead of hardcoding `palette.dark` — the root cause of invisible edges in light mode
- Pass `theme` from `App` into `IssueGraph` so colors always match the active theme
- Increase link opacity from `0.10→0.50` (dark) and `0.08→0.40` (light) so edges are legible against their respective backgrounds

## Root cause

The component hardcoded `palette.dark` for all colors. The link color in dark mode is `rgba(255,255,255,0.10)` — white at 10% opacity. When the app runs in light mode (the default when the system prefers light), the canvas background is white, making the links completely invisible. Even in dark mode they were barely perceptible.

## Test plan

- All 299 unit tests pass (`pnpm test:unit`)
- New tests assert: `nodeRelSize >= 60`, dark and light theme produce different link colors
- Verified visually with Playwright: directed arrows render between nodes in both themes

Closes #89

🤖 Generated with [Claude Code](https://claude.com/claude-code)